### PR TITLE
Insert final newline

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ The EditorConfig Notepad++ plugin supports the following EditorConfig
 * tab_width
 * end_of_line
 * trim_trailing_whitespace
+* insert_final_newline
 * root (only used by EditorConfig core)
 
 ## Bugs and Feature Requests


### PR DESCRIPTION
This adds support for `insert_final_newline` and fixes #4 

I don't know what the default/preferred implementation of `insert_final_newline=false` is, but this removes all newline characters at the end of the file until it sees a non-newline char. So that will result in removing all empty lines at the end of the document.