### PR TITLE
Add AboutBox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 CMakeCache.txt
 *.vcxproj
+*.vcxproj.user
 *.filters
 *.db
 *.opendb

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ project(NppEditorConfig CXX)
 
 set (editorconfig_notepad_plus_plus_VERSION_MAJOR 0)
 set (editorconfig_notepad_plus_plus_VERSION_MINOR 3)
-set (editorconfig_notepad_plus_plus__VERSION_SUBMINOR 0)
+set (editorconfig_notepad_plus_plus__VERSION_SUBMINOR 1)
 
 # set the EDITORCONFIG_CORE_PREFIX. Default is the default installation
 # directory of editorconfig

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 # this file is part of EditorConfig plugin for Notepad++
 # 
-# Copyright (C)2011-2012 EditorConfig Team <http://editorconfig.org>
+# Copyright (C) 2011-2016 EditorConfig Team <http://editorconfig.org>
 # 
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -33,15 +33,18 @@ endif(MSVC)
 
 ## section: source files
 set(NppEditorConfig_SOURCE_FILES
+    ./DlgAbout.cpp
     ./NppPluginEditorConfig.cpp
     ./PluginDefinition.cpp)
 
 ## section: header files
 set(NppEditorConfig_HEADER_FILES
     ./menuCmdID.hpp
+    ./DlgAbout.hpp
     ./Notepad_plus_msgs.hpp
     ./PluginDefinition.hpp
     ./PluginInterface.hpp
+    ./Resource.hpp
     ./Scintilla.hpp)
 
 include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/DlgAbout.cpp
+++ b/src/DlgAbout.cpp
@@ -1,0 +1,94 @@
+// this file is part of EditorConfig plugin for Notepad++
+//
+// Copyright (C) 2011-2016 EditorConfig Team <http://editorconfig.org>
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either
+// version 2 of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//
+
+#include <windows.h>
+#include <stdio.h>
+#include <string.h>
+#include <commctrl.h>
+#include "PluginDefinition.hpp"
+#include "Resource.hpp"
+
+//
+// Initialize the dialog
+//
+static BOOL onInitDialog(HWND hDlg)
+{
+    centerWindow(hDlg);
+
+    // Get the version of the Core-C library
+    int major, minor, subminor;
+    editorconfig_get_version(&major, &minor, &subminor);
+
+    // And put in the dialog
+    TCHAR version[MAX_PATH];
+    swprintf(version, MAX_PATH, TEXT("%d.%d.%d"), major, minor, subminor);
+    SetDlgItemText(hDlg, IDC_CORE_VERSION, version);
+
+    // Let windows set focus
+    return TRUE;
+}
+
+//
+// Handle all the messages for the dialog
+//
+static BOOL CALLBACK dlgProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
+{
+    switch(message)
+    {
+        case WM_INITDIALOG:
+        {
+            return onInitDialog(hDlg);
+        }
+        case WM_NOTIFY:
+        {
+            switch (((LPNMHDR)lParam)->code)
+            {
+                case NM_CLICK:
+                case NM_RETURN:
+                {
+                    PNMLINK pNMLink = (PNMLINK) lParam;
+                    LITEM item = pNMLink->item;
+                    ShellExecute(NULL, L"open", item.szUrl, NULL, NULL, SW_SHOW);
+                }
+            }
+            return FALSE;
+        }
+        case WM_COMMAND:
+        {
+            switch(LOWORD(wParam))
+            {
+                case IDCANCEL:
+                {
+                    EndDialog(hDlg, 0);
+                    return TRUE;
+                }
+            }
+            return FALSE;
+        }
+    }
+    return FALSE;
+}
+
+//
+// Show the About Dialog
+//
+void showAboutDlg()
+{
+    DialogBox(hInst, MAKEINTRESOURCE(IDD_ABOUTBOX), nppData._nppHandle, (DLGPROC) dlgProc);
+}

--- a/src/DlgAbout.hpp
+++ b/src/DlgAbout.hpp
@@ -1,0 +1,22 @@
+// this file is part of EditorConfig plugin for Notepad++
+//
+// Copyright (C) 2011-2016 EditorConfig Team <http://editorconfig.org>
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either
+// version 2 of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//
+
+#pragma once
+
+extern void showAboutDlg();

--- a/src/NppPluginEditorConfig.cpp
+++ b/src/NppPluginEditorConfig.cpp
@@ -21,7 +21,6 @@
 #include "PluginDefinition.hpp"
 
 extern FuncItem funcItem[nbFunc];
-extern NppData nppData;
 
 BOOL APIENTRY DllMain(HANDLE hModule, 
         DWORD  reasonForCall, 

--- a/src/PluginDefinition.cpp
+++ b/src/PluginDefinition.cpp
@@ -1,7 +1,7 @@
 //this file is part of EditorConfig plugin for Notepad++
 //
 //Copyright (C)2003 Don HO <donho@altern.org>
-//Copyright (C)2011 EditorConfig Team <http://editorconfig.org>
+//Copyright (C)2011-2016 EditorConfig Team <http://editorconfig.org>
 //
 //This program is free software; you can redistribute it and/or
 //modify it under the terms of the GNU General Public License
@@ -20,6 +20,7 @@
 
 #include "PluginDefinition.hpp"
 #include "menuCmdID.hpp"
+#include "DlgAbout.hpp"
 
 //
 // The plugin data that Notepad++ needs
@@ -32,10 +33,16 @@ FuncItem funcItem[nbFunc];
 NppData nppData;
 
 //
+// Handle to the Notepad++ instance
+//
+HINSTANCE hInst;
+
+//
 // Initialize your plugin data here
-// It will be called while plugin loading   
+// It will be called while plugin loading
 void pluginInit(HANDLE hModule)
 {
+    hInst = (HINSTANCE) hModule;
 }
 
 //
@@ -299,7 +306,6 @@ void onReloadEditorConfig()
 // You should fill your plugins commands here
 void commandMenuInit()
 {
-
     //--------------------------------------------//
     //-- STEP 3. CUSTOMIZE YOUR PLUGIN COMMANDS --//
     //--------------------------------------------//
@@ -312,6 +318,11 @@ void commandMenuInit()
     //            );
     setCommand(0, TEXT("Reload EditorConfig for this file"),
             onReloadEditorConfig, NULL, false);
+
+    // Separator
+    setCommand(1, TEXT(""), NULL, NULL, false);
+
+    setCommand(2, TEXT("About..."), showAboutDlg, NULL, false);
 }
 
 //
@@ -326,12 +337,9 @@ void commandMenuCleanUp()
 //
 // This function help you to initialize your plugin commands
 //
-bool setCommand(size_t index, TCHAR *cmdName, PFUNCPLUGINCMD pFunc, ShortcutKey *sk, bool check0nInit) 
+bool setCommand(size_t index, TCHAR *cmdName, PFUNCPLUGINCMD pFunc, ShortcutKey *sk, bool check0nInit)
 {
     if (index >= nbFunc)
-        return false;
-
-    if (!pFunc)
         return false;
 
     lstrcpy(funcItem[index]._itemName, cmdName);
@@ -342,3 +350,25 @@ bool setCommand(size_t index, TCHAR *cmdName, PFUNCPLUGINCMD pFunc, ShortcutKey 
     return true;
 }
 
+//
+// Center the window, relative the NPP-window
+//
+void centerWindow(HWND hDlg)
+{
+    RECT rc;
+    GetClientRect(nppData._nppHandle, &rc);
+
+    POINT center;
+    int w = rc.right - rc.left;
+    int h = rc.bottom - rc.top;
+    center.x = rc.left + (w / 2);
+    center.y = rc.top + (h / 2);
+    ClientToScreen(nppData._nppHandle, &center);
+
+    RECT dlgRect;
+    GetClientRect(hDlg, &dlgRect);
+    int x = center.x - ((dlgRect.right - dlgRect.left) / 2);
+    int y = center.y - ((dlgRect.bottom - dlgRect.top) / 2);
+
+    SetWindowPos(hDlg, HWND_TOP, x, y, -1, -1, SWP_NOSIZE | SWP_SHOWWINDOW);
+}

--- a/src/PluginDefinition.hpp
+++ b/src/PluginDefinition.hpp
@@ -1,7 +1,7 @@
 //this file is part of EditorConfig plugin for Notepad++
 //
 //Copyright (C)2003 Don HO <donho@altern.org>
-//Copyright (C)2011 EditorConfig Team <http://editorconfig.org>
+//Copyright (C)2011-2016 EditorConfig Team <http://editorconfig.org>
 //
 //This program is free software; you can redistribute it and/or
 //modify it under the terms of the GNU General Public License
@@ -56,8 +56,12 @@ const TCHAR NPP_PLUGIN_NAME[] = TEXT("EditorConfig");
 //
 // Here define the number of your plugin commands
 //
-const int nbFunc = 2;
+const int nbFunc = 3;
 
+
+struct NppData;
+extern HINSTANCE hInst;
+extern NppData nppData;
 
 //
 // Initialization of your plugin data
@@ -95,6 +99,11 @@ void onBeforeSave(HWND hWnd);
 // Function which sets your command
 //
 bool setCommand(size_t index, TCHAR *cmdName, PFUNCPLUGINCMD pFunc, ShortcutKey *sk = NULL, bool check0nInit = false);
+
+//
+// Center the window, relative the NPP-window
+//
+void centerWindow(HWND hDlg);
 
 
 #endif //PLUGINDEFINITION_HPP

--- a/src/Resource.hpp
+++ b/src/Resource.hpp
@@ -1,0 +1,13 @@
+#ifndef RESOURCE_H
+#define RESOURCE_H
+
+#ifndef IDC_STATIC 
+#define IDC_STATIC -1
+#endif
+
+// About dialog
+#define IDD_ABOUTBOX                250
+#define IDC_CORE_VERSION            251
+#define IDC_SYSLINK                 252
+
+#endif // RESOURCE_H

--- a/src/version.rc.in
+++ b/src/version.rc.in
@@ -1,21 +1,24 @@
 // this file is part of EditorConfig plugin for Notepad++
-// 
-// Copyright (C)2011-2012 EditorConfig Team <http://editorconfig.org>
-// 
+//
+// Copyright (C)2011-2016 EditorConfig Team <http://editorconfig.org>
+//
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
 // as published by the Free Software Foundation; either
 // version 2 of the License, or (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
-// 
+//
+
+#include <windows.h>
+#include "Resource.hpp"
 
 #define VER_FILEVERSION @editorconfig_notepad_plus_plus_VERSION_MAJOR@,@editorconfig_notepad_plus_plus_VERSION_MINOR@,@editorconfig_notepad_plus_plus__VERSION_SUBMINOR@,0
 #define VER_FILEVERSION_STR "@editorconfig_notepad_plus_plus_VERSION_MAJOR@.@editorconfig_notepad_plus_plus_VERSION_MINOR@.@editorconfig_notepad_plus_plus__VERSION_SUBMINOR@.0\0"
@@ -35,7 +38,7 @@
             VALUE "FileDescription", "EditorConfig plugin for Notepad++"
             VALUE "FileVersion", VER_FILEVERSION_STR
             VALUE "InternalName", "NppEditorConfig"
-            VALUE "LegalCopyright", "Copyright (C) 2011-2012 EditorConfig Team <http://editorconfig.org>"
+            VALUE "LegalCopyright", "Copyright (C) 2011-2016 EditorConfig Team <http://editorconfig.org>"
             VALUE "OriginalFilename", "NppEditorConfig"
             VALUE "ProductName", "EditorConfig plugin for Notepad++"
             VALUE "ProductVersion", VER_PRODUCTVERSION_STR
@@ -45,4 +48,23 @@
     {
         VALUE "Translation", 0x0409, 0x04B0
     }
+}
+
+
+IDD_ABOUTBOX DIALOGEX 0, 0, 224, 126
+STYLE DS_SHELLFONT | WS_BORDER | WS_POPUP | WS_SYSMENU
+FONT 8, "MS Shell Dlg", 0, 0, 1
+{
+    GROUPBOX        "EditorConfig plug-in", IDC_STATIC, 10, 9, 201, 93, BS_CENTER
+    LTEXT           "Authors:", IDC_STATIC, 30, 23, 64, 8
+    LTEXT           "EditorConfig Team", IDC_STATIC, 100, 23, 106, 8
+    LTEXT           "Plugin version:", IDC_STATIC, 30, 38, 64, 8
+    LTEXT           VER_PRODUCTVERSION_STR, IDC_STATIC, 100, 38, 106, 8
+    LTEXT           "Core-C version:", IDC_STATIC, 30, 53, 64, 8
+    LTEXT           "", IDC_CORE_VERSION, 100, 53, 106, 8
+    LTEXT           "License:", IDC_STATIC, 30, 68, 64, 8
+    LTEXT           "GPL-2", IDC_STATIC, 100, 68, 106, 8
+    LTEXT           "Site:", IDC_STATIC, 30, 83, 64, 8
+    CONTROL         "<a href=""http://editorconfig.org/"">http://editorconfig.org/</a>", IDC_SYSLINK, "SysLink", NOT WS_TABSTOP, 99, 83, 106, 8
+    PUSHBUTTON      "Close", IDCANCEL, 86, 107, 50, 14
 }


### PR DESCRIPTION
This adds an AboutBox to the plug-in.

The AboutBox shows the version of the plug-in, the core it is linked with and a clickable link to the website of the project.