### PR TITLE
Set language to L_INI

### DIFF
--- a/src/NppPluginEditorConfig.cpp
+++ b/src/NppPluginEditorConfig.cpp
@@ -68,6 +68,7 @@ extern "C" __declspec(dllexport) void beNotified(SCNotification *notifyCode)
 {
     switch (notifyCode->nmhdr.code) {
     case NPPN_BUFFERACTIVATED: // When new file opened, run set the conf
+        setSyntaxFromFilename();
         loadConfig();
         break;
     case NPPN_FILEBEFORESAVE:

--- a/src/PluginDefinition.cpp
+++ b/src/PluginDefinition.cpp
@@ -92,6 +92,19 @@ static HWND getCurrentScintilla()
     return((which == 0) ? nppData._scintillaMainHandle : nppData._scintillaSecondHandle);
 }
 
+//
+// Set the syntax highlighting to "INI" for .editorconfig files
+//
+void setSyntaxFromFilename()
+{
+    // Retrieve the filename
+    WCHAR szFilename[_MAX_PATH];
+    SendMessage(g_nppData._nppHandle, NPPM_GETFILENAME, _MAX_PATH, (LPARAM) szFilename);
+
+    if (wcscmp(szFilename, L".editorconfig") == 0)
+        SendMessage(nppData._nppHandle, NPPM_SETCURRENTLANGTYPE, 0, L_INI);
+}
+
 void loadConfig()
 {
     int name_value_count;

--- a/src/PluginDefinition.cpp
+++ b/src/PluginDefinition.cpp
@@ -99,7 +99,7 @@ void setSyntaxFromFilename()
 {
     // Retrieve the filename
     WCHAR szFilename[_MAX_PATH];
-    SendMessage(g_nppData._nppHandle, NPPM_GETFILENAME, _MAX_PATH, (LPARAM) szFilename);
+    SendMessage(nppData._nppHandle, NPPM_GETFILENAME, _MAX_PATH, (LPARAM) szFilename);
 
     if (wcscmp(szFilename, L".editorconfig") == 0)
         SendMessage(nppData._nppHandle, NPPM_SETCURRENTLANGTYPE, 0, L_INI);

--- a/src/PluginDefinition.hpp
+++ b/src/PluginDefinition.hpp
@@ -85,6 +85,11 @@ void commandMenuInit();
 void commandMenuCleanUp();
 
 //
+// Set the syntax highlighting to "INI" for .editorconfig files
+//
+void setSyntaxFromFilename();
+
+//
 // load config files
 //
 void loadConfig();


### PR DESCRIPTION
EditorConfig files are .ini files, so whenever we open the `.editorconfig` file set the language to L_INI to have syntax highlighting.