### PR TITLE
update editorconfig to 0.12.5

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+ # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -1,0 +1,49 @@
+name: CI_build
+
+on: [push, pull_request]
+
+jobs:
+  build_windows:
+
+    runs-on: windows-2022
+    strategy:
+      max-parallel: 6
+      matrix:
+        build_configuration: [Release, Debug]
+        build_platform: [x64, arm64, x86]
+        build_vsver: [17]
+        PCRE2_VERSION: [10.37]
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+
+    - name: Download PCRE2 sources
+      run: ./init.ps1 -pcre "${{ matrix.PCRE2_VERSION }}"
+
+    - name: Build and install PCRE2
+      run: ./build.ps1 -proj pcre2 -config ${{ matrix.build_configuration }} -arch ${{ matrix.build_platform }} -vsver ${{ matrix.build_vsver }} -init -install
+
+    - name: Build and install editorconfig-core-c
+      run: ./build.ps1 -proj core -config ${{ matrix.build_configuration }} -arch ${{ matrix.build_platform }} -vsver ${{ matrix.build_vsver }} -init -install
+
+    - name: Build and install editorconfig plugin
+      run: ./build.ps1 -proj npp -config ${{ matrix.build_configuration }} -arch ${{ matrix.build_platform }} -vsver ${{ matrix.build_vsver }} -init -install
+
+    - uses: olegtarasov/get-tag@v2.1.1
+      id: tagName
+
+    - name: Archive artifacts
+      if: matrix.build_configuration == 'Release'
+      uses: actions/upload-artifact@v3
+      with:
+          name: NppEditorConfig-${{ steps.tagName.outputs.tag }}-${{ matrix.build_platform }}
+          path: bin\${{ matrix.build_platform }}\NppEditorConfig.dll
+
+
+    - name: Release on tagging
+      uses: softprops/action-gh-release@v1
+      if: startsWith(github.ref, 'refs/tags/') && matrix.build_configuration == 'Release'
+      with:
+          files: NppEditorConfig-${{ steps.tagName.outputs.tag }}-${{ matrix.build_platform }}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 image:
-  - Visual Studio 2017
+  - Visual Studio 2022
 
 only_commits:
   files:
@@ -9,13 +9,14 @@ only_commits:
     - '*.ps1'
 
 environment:
-  PCRE2_VERSION: 10.32
-  EDITORCONFIG_VERSION: 0.12.3
+  PCRE2_VERSION: 10.37
+  EDITORCONFIG_VERSION: 0.12.5
   CONFIG: Release
-  VSVER: 15
+  VSVER: 17
   matrix:
   - ARCH: x64
   - ARCH: x86
+  - ARCH: arm64
 
 install:
   - cmake --version

--- a/build.ps1
+++ b/build.ps1
@@ -9,11 +9,11 @@ param(
     [ValidateSet("Debug", "Release")]
     [string] $config = "Release",
 
-    [ValidateSet("x86", "x64")]
+    [ValidateSet("x86", "x64", "arm64")]
     [string] $arch = "x64",
 
 
-    [ValidateSet("15","14","12")]
+    [ValidateSet("17","16","15","14")]
     [int] $vsver = 15
 )
 
@@ -61,6 +61,12 @@ if ($init) {
     $gen = "Visual Studio "
 
     switch ($vsver) {
+        17 {
+            $gen += "17 2022"
+        }
+        16 {
+            $gen += "16 2019"
+        }
         15 {
             $gen += "15 2017"
         }
@@ -75,8 +81,15 @@ if ($init) {
         }
     }
 
-    if ($arch -eq "x64") {
-        $gen += " Win64"
+    $cmake_arch=""
+    if($arch -eq "x64"){
+        $cmake_arch += "x64"
+    }
+    elseif($arch -eq "x86"){
+        $cmake_arch += "Win32"
+    }
+    elseif($arch -eq "arm64"){
+        $cmake_arch += "ARM64"
     }
 
     New-Item $dest\$arch\$proj -ItemType Directory -ErrorAction SilentlyContinue | Out-Null
@@ -84,19 +97,19 @@ if ($init) {
     try {
         switch ($proj) {
             pcre2 {
-                exec { cmake -G "$gen" -DCMAKE_INSTALL_PREFIX="$PREFIX" `
+                exec { cmake -G "$gen" -A $cmake_arch -DCMAKE_INSTALL_PREFIX="$PREFIX" `
                         -DPCRE2_STATIC_RUNTIME=ON `
                         -DPCRE2_BUILD_PCRE2GREP=OFF `
                         -DPCRE2_BUILD_TESTS=OFF `
                         "../../pcre2" }
             }
             core {
-                exec { cmake -G "$gen" -DCMAKE_INSTALL_PREFIX="$PREFIX" `
+                exec { cmake -G "$gen" -A $cmake_arch -DCMAKE_INSTALL_PREFIX="$PREFIX" `
                         -DPCRE2_STATIC=ON `
                         "../../editorconfig-core-c" }
             }
             npp {
-                exec { cmake -G "$gen" -DEDITORCONFIG_CORE_PREFIX="$(Resolve-Path $PREFIX)" "../../../." }
+                exec { cmake -G "$gen" -A $cmake_arch -DEDITORCONFIG_CORE_PREFIX="$(Resolve-Path $PREFIX)" "../../../." }
             }
         }
     }

--- a/init.ps1
+++ b/init.ps1
@@ -1,6 +1,6 @@
 param(
-    $pcre="10.32",
-    $edc="0.12.3"
+    $pcre="10.37",
+    $edc="0.12.5"
 )
 
 $ErrorActionPreference="Stop"
@@ -15,8 +15,8 @@ New-Item $dest -ItemType Directory -ErrorAction SilentlyContinue | Out-Null
 #####################################################################
 # pcre
 #####################################################################
-$url = "https://ftp.pcre.org/pub/pcre/pcre2-$($pcre).zip"
-$output = "$dest\pcre2-$($pcre).zip"
+$url = "https://github.com/PCRE2Project/pcre2/releases/download/pcre2-$($pcre)/pcre2-$($pcre).zip"
+$output = "$dest\pcre-$($pcre).zip"
 
 "Downloading pcre2 v$pcre sources" | Write-Host -ForegroundColor DarkGreen
 Start-BitsTransfer -Source $url -Destination $output

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -75,4 +75,6 @@ set_target_properties(NppEditorConfig_unicode PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib/unicode)
 target_link_libraries(NppEditorConfig_unicode editorconfig_static)
 target_link_libraries(NppEditorConfig_unicode Shlwapi)
-target_link_libraries(NppEditorConfig_unicode pcre2-8)
+target_link_libraries(NppEditorConfig_unicode
+                      debug pcre2-8d
+                      optimized pcre2-8)


### PR DESCRIPTION
- update editorconfig to 0.12.5
- update pcre2 to 10.37 and fix download location (newer pcre2 versions need a updated tag of editorconfig not yet available)
- prepare scripts for newer VS versions and arm64
- correct debug build
- added github action CI workflow with release update on tagging
- CI builds on VS2022 images 